### PR TITLE
第6フェーズ: Context APIで認証状態の管理

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,23 +1,29 @@
 import './App.css'
-import MainLayout from './layouts/MainLayout'
 import { BrowserRouter } from 'react-router-dom'
 import { Routes, Route } from 'react-router-dom'
+import { AuthProvider } from './contexts/AuthContext'
+import MainLayout from './layouts/MainLayout'
 import Dashboard from './pages/Dashboard'
 import Users from './pages/Users'
 import Settings from './pages/Settings'
 import Login from './pages/Login'
-import { AuthProvider } from './contexts/AuthContext'
+import PublicRoute from './components/PublicRoute'
+import ProtectedRoute from './components/ProtectedRoute'
 
 export default function App() {
   return (
     <AuthProvider>
       <BrowserRouter>
         <Routes>
-          <Route path="/login" element={<Login />} />
-          <Route path="/" element={<MainLayout />}>
-            <Route index element={<Dashboard />} />
-            <Route path="users" element={<Users />} />
-            <Route path="settings" element={<Settings />} />
+          <Route element={<PublicRoute />}>
+            <Route path="/login" element={<Login />} />
+          </Route>
+          <Route element={<ProtectedRoute />}>
+            <Route path="/" element={<MainLayout />}>
+              <Route index element={<Dashboard />} />
+              <Route path="users" element={<Users />} />
+              <Route path="settings" element={<Settings />} />
+            </Route>
           </Route>
         </Routes>
       </BrowserRouter>

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -6,18 +6,21 @@ import Dashboard from './pages/Dashboard'
 import Users from './pages/Users'
 import Settings from './pages/Settings'
 import Login from './pages/Login'
+import { AuthProvider } from './contexts/AuthContext'
 
 export default function App() {
   return (
-    <BrowserRouter>
-      <Routes>
-        <Route path="/login" element={<Login />} />
-        <Route path="/" element={<MainLayout />}>
-          <Route index element={<Dashboard />} />
-          <Route path="users" element={<Users />} />
-          <Route path="settings" element={<Settings />} />
-        </Route>
-      </Routes>
-    </BrowserRouter>
+    <AuthProvider>
+      <BrowserRouter>
+        <Routes>
+          <Route path="/login" element={<Login />} />
+          <Route path="/" element={<MainLayout />}>
+            <Route index element={<Dashboard />} />
+            <Route path="users" element={<Users />} />
+            <Route path="settings" element={<Settings />} />
+          </Route>
+        </Routes>
+      </BrowserRouter>
+    </AuthProvider>
   );
 }

--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -1,5 +1,5 @@
 import { Power } from "lucide-react"
-import { useAuth } from '@/hooks/useAuth'
+import { useAuth } from '@/contexts/AuthContext'
 import { useNavigate } from 'react-router-dom'
 
 export default function Header() {

--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -1,0 +1,34 @@
+import { Power } from "lucide-react"
+import { useAuth } from '@/hooks/useAuth'
+import { useNavigate } from 'react-router-dom'
+
+export default function Header() {
+  const { user, logout } = useAuth()
+  const navigate = useNavigate()
+  const handleLogout = () => {
+    logout()
+    navigate('/login')
+  }
+  
+  return (
+    <header className="bg-gray-800 text-white h-16 flex items-center justify-between px-6 shadow-lg">
+      <div className="flex items-center">
+        <h1 className="text-xl font-bold">管理画面</h1>
+      </div>
+      
+      <div className="flex items-center space-x-4">
+          <div className="mr-2 text-sm">
+            <span className="text-gray-500 mr-2">ようこそ</span>
+            <span className="font-medium">{user?.name}</span>
+            <span className="text-gray-500 ml-2">さん</span>
+          </div>
+          <button
+            onClick={handleLogout}
+            className="flex items-center text-gray-600 hover:text-gray-900 bg-gray-100 hover:bg-gray-200 px-3 py-2 rounded-full text-sm transition-colors"
+          >
+            <Power className="h-5 w-5" />
+        </button>
+      </div>
+    </header>
+  )
+}

--- a/src/components/ProtectedRoute.tsx
+++ b/src/components/ProtectedRoute.tsx
@@ -1,4 +1,4 @@
-import { useAuth } from '@/hooks/useAuth'
+import { useAuth } from '@/contexts/AuthContext'
 import { Navigate, Outlet } from 'react-router-dom'
 
 export default function ProtectedRoute() {

--- a/src/components/ProtectedRoute.tsx
+++ b/src/components/ProtectedRoute.tsx
@@ -1,0 +1,10 @@
+import { useAuth } from '@/hooks/useAuth'
+import { Navigate, Outlet } from 'react-router-dom'
+
+export default function ProtectedRoute() {
+  const { isAuthenticated } = useAuth()
+  if (!isAuthenticated) {
+    return <Navigate to="/login" replace />
+  }
+  return <Outlet />
+}

--- a/src/components/PublicRoute.tsx
+++ b/src/components/PublicRoute.tsx
@@ -1,0 +1,10 @@
+import { useAuth } from '@/hooks/useAuth'
+import { Navigate, Outlet } from 'react-router-dom'
+
+export default function PublicRoute() {
+  const { isAuthenticated } = useAuth()
+  if (isAuthenticated) {
+    return <Navigate to="/" replace />
+  }
+  return <Outlet />
+}

--- a/src/components/PublicRoute.tsx
+++ b/src/components/PublicRoute.tsx
@@ -1,4 +1,4 @@
-import { useAuth } from '@/hooks/useAuth'
+import { useAuth } from '@/contexts/AuthContext'
 import { Navigate, Outlet } from 'react-router-dom'
 
 export default function PublicRoute() {

--- a/src/components/Sidebar.tsx
+++ b/src/components/Sidebar.tsx
@@ -27,7 +27,7 @@ export default function Sidebar() {
       {/* タイトルエリア */}
       <div className="px-5 py-6 flex items-center justify-between max-[1000px]:hidden">
         {!isCollapsed && (
-          <h2 className="text-xl font-bold">
+          <h2 className="text-lg font-bold">
             メニュー
           </h2>
         )}
@@ -43,7 +43,7 @@ export default function Sidebar() {
       </div>
 
       {/* メニューエリア */}
-      <nav className="mt-8">
+      <nav className="mt-2">
         <ul className="px-3 space-y-2">
           {menuItems.map((item) => {
             const Icon = item.icon

--- a/src/contexts/AuthContext.tsx
+++ b/src/contexts/AuthContext.tsx
@@ -1,4 +1,4 @@
-import { createContext, useState, useEffect } from 'react'
+import { createContext, useState, useEffect, useContext } from 'react'
 
 type User = {
   id: string
@@ -79,4 +79,9 @@ export const AuthProvider = ({ children }: { children: React.ReactNode }) => {
       {children}
     </AuthContext.Provider>
   )
+}
+
+export const useAuth = () => {
+  const context = useContext(AuthContext)
+  return context
 }

--- a/src/contexts/AuthContext.tsx
+++ b/src/contexts/AuthContext.tsx
@@ -1,0 +1,70 @@
+import { createContext, useState, useEffect } from 'react'
+
+type User = {
+  id: string
+  name: string
+  email: string
+}
+
+type AuthContextType = {
+  user: User | null
+  login: (email: string, password: string) => boolean
+  logout: () => void
+  isAuthenticated: boolean
+}
+
+// モックユーザー情報
+const mockUser = {
+  id: '1',
+  name: 'Yamada Yuta',
+  email: 'yamada@example.com',
+  password: 'password'
+}
+
+// コンテキストを作成
+export const AuthContext = createContext<AuthContextType | undefined>(undefined)
+
+// 認証プロバイダーを作成
+export const AuthProvider = ({ children }: { children: React.ReactNode }) => {
+  const [user, setUser] = useState<User | null>(null)
+  const [isAuthenticated, setIsAuthenticated] = useState(false)
+  
+  // ローカルストレージからユーザー情報を取得
+  useEffect(() => {
+    const storedUser = localStorage.getItem('user')
+    if (storedUser) {
+      setUser(JSON.parse(storedUser))
+      setIsAuthenticated(true)
+    }
+  }, [])
+
+  // ログイン処理
+  const login = (email: string, password: string) => {
+    if (email === mockUser.email && password === mockUser.password) {
+      const authenticatedUser = {
+        id: mockUser.id,
+        name: mockUser.name,
+        email: mockUser.email
+      }
+      setUser(authenticatedUser)
+      setIsAuthenticated(true)
+      localStorage.setItem('user', JSON.stringify(authenticatedUser))
+      return true
+    }
+    return false
+  }
+
+  // ログアウト処理
+  const logout = () => {
+    setUser(null)
+    setIsAuthenticated(false)
+    localStorage.removeItem('user')
+  }
+
+  // 認証プロバイダーを提供
+  return (
+    <AuthContext.Provider value={{ user, login, logout, isAuthenticated }}>
+      {children}
+    </AuthContext.Provider>
+  )
+}

--- a/src/contexts/AuthContext.tsx
+++ b/src/contexts/AuthContext.tsx
@@ -21,8 +21,20 @@ const mockUser = {
   password: 'password'
 }
 
+// デフォルト値の定義
+const defaultAuthContext: AuthContextType = {
+  user: null,
+  login: () => {
+    throw new Error('loginはAuthProviderの内側でのみ使用できます')
+  },
+  logout: () => {
+    throw new Error('logoutはAuthProviderの内側でのみ使用できます')
+  },
+  isAuthenticated: false
+}
+
 // コンテキストを作成
-export const AuthContext = createContext<AuthContextType | undefined>(undefined)
+export const AuthContext = createContext<AuthContextType>(defaultAuthContext)
 
 // 認証プロバイダーを作成
 export const AuthProvider = ({ children }: { children: React.ReactNode }) => {

--- a/src/hooks/useAuth.ts
+++ b/src/hooks/useAuth.ts
@@ -1,7 +1,0 @@
-import { useContext } from 'react'
-import { AuthContext } from '@/contexts/AuthContext'
-
-export const useAuth = () => {
-  const context = useContext(AuthContext)
-  return context
-}

--- a/src/hooks/useAuth.ts
+++ b/src/hooks/useAuth.ts
@@ -1,0 +1,10 @@
+import { useContext } from 'react'
+import { AuthContext } from '@/contexts/AuthContext'
+
+export const useAuth = () => {
+  const context = useContext(AuthContext)
+  if (!context) {
+    throw new Error('useAuthはAuthProviderの内側でのみ使用できます')
+  }
+  return context
+}

--- a/src/hooks/useAuth.ts
+++ b/src/hooks/useAuth.ts
@@ -3,8 +3,5 @@ import { AuthContext } from '@/contexts/AuthContext'
 
 export const useAuth = () => {
   const context = useContext(AuthContext)
-  if (!context) {
-    throw new Error('useAuthはAuthProviderの内側でのみ使用できます')
-  }
   return context
 }

--- a/src/layouts/MainLayout.tsx
+++ b/src/layouts/MainLayout.tsx
@@ -1,14 +1,18 @@
 import Sidebar from '../components/Sidebar'
 import MainContent from '../components/MainContent'
+import Header from '../components/Header'
 import { Outlet } from 'react-router-dom'
 
 export default function MainLayout(){
   return (
-    <div className="flex h-screen">
-      <Sidebar />
-      <MainContent>
-        <Outlet />
-      </MainContent>
+    <div className="flex flex-col h-screen">
+      <Header />
+      <div className="flex flex-1 overflow-hidden">
+        <Sidebar />
+        <MainContent>
+          <Outlet />
+        </MainContent>
+      </div>
     </div>
   )
 }

--- a/src/pages/Login.tsx
+++ b/src/pages/Login.tsx
@@ -1,7 +1,7 @@
 import { useForm, SubmitHandler } from 'react-hook-form'
 import { zodResolver } from '@hookform/resolvers/zod'
 import { z } from 'zod'
-import { useAuth } from '@/hooks/useAuth'
+import { useAuth } from '@/contexts/AuthContext'
 import { useNavigate } from 'react-router-dom'
 
 const formSchema = z.object({

--- a/src/pages/Login.tsx
+++ b/src/pages/Login.tsx
@@ -1,6 +1,8 @@
 import { useForm, SubmitHandler } from 'react-hook-form'
 import { zodResolver } from '@hookform/resolvers/zod'
 import { z } from 'zod'
+import { useAuth } from '@/hooks/useAuth'
+import { useNavigate } from 'react-router-dom'
 
 const formSchema = z.object({
   email: z.string().min(1, { message: 'メールアドレスを入力してください。' }),
@@ -9,12 +11,24 @@ const formSchema = z.object({
 type FormData = z.infer<typeof formSchema>
 
 export default function Login() {
-  const { register, handleSubmit, formState: { errors } } = useForm<FormData>({
+  const { login } = useAuth()
+  const navigate = useNavigate()
+
+  const { register, handleSubmit, formState: { errors }, setError } = useForm<FormData>({
     resolver: zodResolver(formSchema)
   });
 
   const onSubmit: SubmitHandler<FormData> = (data) => {
-    console.log(data)
+    try {
+      const success = login(data.email, data.password)
+      if (success) {
+        navigate('/')
+      } else {
+        setError("password", { message: 'メールアドレスまたはパスワードが正しくありません。' })
+      }
+    } catch (error) {
+      setError("password", { message: 'ログイン中にエラーが発生しました。' })
+    }
   }
 
   return (


### PR DESCRIPTION

以下の要件で実装しました。
ご確認とレビューよろしくお願いいたします。

> - AuthContextの作成
> - ユーザー情報の管理（モックデータで実装）
> - localStorage での状態保持
> - ログインしたuserだけがsideabarのあるページを開けるように変更する
> - ログイン・ログアウト機能の実装


【つまづきどころ】
 - contextとproviderの理解に時間がかかりました
理解してからは割とすんなり実装が進みました
 - ルーティングにおいてPublicRouteは不要かもと思いましたが
メールアドレス忘れとか未認証のページも複数できると想定して作りました
 - 参考にしたページではカスタムフックをcontext定義ファイルと一緒に記述してましたが、複数箇所呼び出しなのでhooksディレクトリに移動しました
https://zenn.dev/idapan/articles/0a2053e54b41e0
 - 今回の案件においてcontextAPIを使うご予定はありますか？あまり状態が変化しない箇所であれば。。。でしょうか



```
ログイン用📝
メールアドレス
yamada@example.com
パスワード
password
```

![スクリーンショット 2025-04-18 10 28 04](https://github.com/user-attachments/assets/be1d4c7e-b3ab-4a84-b0c0-2c09ed28e057)
![スクリーンショット 2025-04-18 10 00 02](https://github.com/user-attachments/assets/dfd33434-3e1c-4abf-9852-cec008afa69c)
